### PR TITLE
Making sure that NetMQMonitor can always be stopped/disposed

### DIFF
--- a/src/NetMQ/Monitoring/NetMQMonitor.cs
+++ b/src/NetMQ/Monitoring/NetMQMonitor.cs
@@ -174,10 +174,16 @@ namespace NetMQ.Monitoring
         }
 
         private void InternalClose()
-        {            
-            MonitoringSocket.Disconnect(Endpoint);            
-            IsRunning = false;
-            m_isStoppedEvent.Set();
+        {
+            try
+            {
+                MonitoringSocket.Disconnect(Endpoint);
+            }
+            finally 
+            {
+                IsRunning = false;
+                m_isStoppedEvent.Set();
+            }
         }
 
         public void AttachToPoller(Poller poller)


### PR DESCRIPTION
This fix will ensure that the NetMQMonitor can be Stopped/Disposed even if an exception is raised from the MonitoringSocket.

It would interesting to know why Disconnect fails in this specific case. I don't know the internals of NetMQ enough. Maybe it's the designed behavior. In any case the NetMQMonitor should always complete properly (setting IsRunning = false and isStoppedEvent).
